### PR TITLE
WarnOnError Option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## History
 
+- v2.1.3 January 10th, 2015
+  - Added warnOnError to config - [@jtwebman](http://github.com/jtwebman)
+  - Updated documentation
+
 - v2.1.2 December 19th, 2013
   - Handles all DocPad events - [@evantill](http://github.com/evantill)
   - Updated documentation

--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ The following will run the `"cssmin"` and `"uglify"` tasks from Grunt during the
       writeAfter: false
       generateAfter: ["cssmin", "uglify"]
 ```
+The following can be used if you want the default tasks to run but just show
+a warning if the Gruntfile fails and continue running.
 
+```coffeescript
+  plugins:
+    grunt:
+      warnOnError: true
+```
 
 <!-- HISTORY/ -->
 
@@ -77,6 +84,7 @@ These amazing people have contributed code to this project:
 
 - Rob Loach (https://github.com/robloach) - [view contributions](https://github.com/robloach/docpad-plugin-grunt/commits?author=RobLoach)
 - Eric Vantillard (https://github.com/evantill) - [view contributions](https://github.com/robloach/docpad-plugin-grunt/commits?author=evantill)
+- Jeff Turner (https://github.com/jtwebman) - [view contributions](https://github.com/robloach/docpad-plugin-grunt/commits?author=jtwebman)
 
 [Become a contributor!](https://github.com/robloach/docpad-plugin-grunt/blob/master/CONTRIBUTING.md#files)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docpad-plugin-grunt",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Run Grunt tasks when building with DocPad.",
   "license": "MIT",
   "homepage": "http://github.com/robloach/docpad-plugin-grunt",
@@ -21,7 +21,8 @@
   ],
   "contributors": [
     "Rob Loach (http://robloach.net)",
-    "Eric Vantillard (https://github.com/evantill)"
+    "Eric Vantillard (https://github.com/evantill)",
+    "Jeff Turner (https://github.com/jtwebman)"
   ],
   "bugs": {
     "url": "http://github.com/robloach/docpad-plugin-grunt/issues"

--- a/src/grunt.plugin.coffee
+++ b/src/grunt.plugin.coffee
@@ -8,6 +8,7 @@ module.exports = (BasePlugin) ->
     # Configuration
     config:
       writeAfter: []
+      warnOnError: false
 
     createEventHandlers: (docpad) ->
       for eventName in docpad.getEvents()
@@ -40,6 +41,7 @@ module.exports = (BasePlugin) ->
     processGrunt: (tasks, opts, next) ->
       # Prepare
       docpad = @docpad
+      config = @getConfig()
       rootPath = @docpad.getConfig().rootPath
 
       # Find the Grunt path
@@ -55,12 +57,16 @@ module.exports = (BasePlugin) ->
 
         # Execute
         @safeps.spawn command, {cwd: rootPath, output: true}, (err) ->
-          docpad.log "warn", "Grunt Error: " + err.message  if err
-          next()
+          if err
+            if config.warnOnError
+              docpad.log "warn", "Grunt Error: " + err.message
+            else
+              return next(err)
+          return next()
 
       else
         err = new Error('Could not find the Grunt command line interface.')
-        return next(err); err
+        return next(err)
 
       # Chain
       @

--- a/src/grunt.plugin.coffee
+++ b/src/grunt.plugin.coffee
@@ -39,6 +39,7 @@ module.exports = (BasePlugin) ->
     # Process the Grunt tasks.
     processGrunt: (tasks, opts, next) ->
       # Prepare
+      docpad = @docpad
       rootPath = @docpad.getConfig().rootPath
 
       # Find the Grunt path
@@ -53,7 +54,9 @@ module.exports = (BasePlugin) ->
         command.push task for task in tasks or []
 
         # Execute
-        @safeps.spawn(command, {cwd: rootPath, output: true}, next)
+        @safeps.spawn command, {cwd: rootPath, output: true}, (err) ->
+          docpad.log "warn", "Grunt Error: " + err.message  if err
+          next()
 
       else
         err = new Error('Could not find the Grunt command line interface.')


### PR DESCRIPTION
I added an option to the grunt plugin to warn on Grunt run error instead of an error. I use it on my project now for running grunt-jslint. Let me know if I missed anything.