### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "docpad-plugin-grunt",
   "version": "2.2.0",
   "description": "Run Grunt tasks when building with DocPad.",
-  "license": {
-    "type": "MIT"
-  },
+  "license": "MIT",
   "homepage": "http://github.com/robloach/docpad-plugin-grunt",
   "keywords": [
     "docpad",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
